### PR TITLE
Fix 403 error when fetching Reddit data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Run the `persona_builder.py` script with a Reddit profile URL:
 python persona_builder.py https://www.reddit.com/user/example_user/
 
 ```
+
+The script includes a browser-like `User-Agent` header so it can access
+Reddit's public JSON feeds without authentication. If you encounter a `403`
+error, ensure your network allows outbound HTTPS requests.

--- a/persona_builder.py
+++ b/persona_builder.py
@@ -2,7 +2,11 @@ import re
 import requests
 from collections import Counter
 
-USER_AGENT = "UserPersonaBuilder/0.1"
+# Reddit blocks requests that do not provide a real User-Agent string.  Using a
+# generic browser UA avoids 403 errors when accessing the public JSON endpoints.
+USER_AGENT = (
+    "Mozilla/5.0 (compatible; UserPersonaBuilder/1.0; +https://example.com)"
+)
 
 STOP_WORDS = {
     'the','and','that','have','for','with','this','http','https','from','they','you','your',


### PR DESCRIPTION
## Summary
- use a browser-like User-Agent string so Reddit JSON endpoints don't return 403
- document the user agent behaviour in the README

## Testing
- `pip install requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68747a7926908330a581b851ed247d5a